### PR TITLE
fix failed jest test and increase cypress default response timeout 

### DIFF
--- a/client/cypress.config.js
+++ b/client/cypress.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from 'cypress';
 export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:5173',
-    responseTimeout: 10000,
+    responseTimeout: 15000,
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/server/src/controllers/links.controller.js
+++ b/server/src/controllers/links.controller.js
@@ -75,16 +75,18 @@ editLink = async (req, res) => {
     }
 
     const link = await Link.findOne({ short: req.params.short });
+
     if (!link) {
       return res.status(404).json({ success: false, message: 'Link not found.' });
     }
 
-    if (!validator.isURL(req.body.url)) {
+    if (req.body.url && !validator.isURL(req.body.url)) {
       return res.status(422).json({ success: false, message: 'invalid url' });
     }
 
     link.url = req.body.url??link.url;
     link.title = req.body.title??link.title;
+
     await link.save();
 
     res.status(200).json({ success: true, message: 'Link updated successfully.' });


### PR DESCRIPTION
## Summary
previous PR broke one of the tests. 
cypress 5000ms response timeout is causing frontend tests to fail occasionally 

## Checklist
- [x] tested locally.
- [x] No error nor warning in the console.

[upload the screenshot here] (optional)
